### PR TITLE
[hotfix] add DISCLAIMER file And update NOTICE years

### DIFF
--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,0 +1,7 @@
+Apache Paimon (incubating) is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+
+Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications,
+and decision making process have stabilized in a manner consistent with other successful ASF projects.
+
+While incubation status is not necessarily a reflection of the completeness or stability of the code,
+it does indicate that the project has yet to be fully endorsed by the ASF.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ When using these dependencies it is recommended to work directly against the sha
 
 We currently do not release jars containing the shaded sources due to the unanswered legal questions raised [here](https://github.com/apache/flink-shaded/issues/25).
 
-However, it is possible to build these jars locally by cloning the repository and calling `mvn package -Dshade-sources`.
+However, it is possible to build these jars locally by cloning the repository and calling `mvn clean package -Dshade-sources`.
 
 ## About
 

--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,7 @@ under the License.
                             <!-- The ApacheNoticeResourceTransformer collects and aggregates NOTICE files -->
                             <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
                                 <projectName>Apache Paimon-shade</projectName>
+                                <inceptionYear>${project.inceptionYear}</inceptionYear>
                                 <encoding>UTF-8</encoding>
                             </transformer>
                         </transformers>


### PR DESCRIPTION
this pr close #7 


Unzip the package META-INF/NOTICE file:

<img width="926" alt="image" src="https://user-images.githubusercontent.com/37063904/229262232-7719c333-da1f-4a5c-b0e7-b78d5ca8c811.png">

note:

https://github.com/apache/maven-shade-plugin/blob/7e22fe8204ad316e1d37f297eaf4aea7dbbf7797/src/main/java/org/apache/maven/plugins/shade/resource/ApacheNoticeResourceTransformer.java#L92-L105

In the NOTICE file generated in maven-shade-plugin, there is a process of judging that the starting year is this year, so `Copyright 2023 The Apache Software Foundation` is displayed in the NOTICE file instead of `Copyright 2023 The Apache Software Foundation`


