### PR TITLE
[ci] Adapt JarFileChecker to the new plugin classes layout

### DIFF
--- a/tools/ci/paimon-ci-tools/src/main/java/org/apache/paimon/tools/ci/licensecheck/JarFileChecker.java
+++ b/tools/ci/paimon-ci-tools/src/main/java/org/apache/paimon/tools/ci/licensecheck/JarFileChecker.java
@@ -203,7 +203,7 @@ public class JarFileChecker {
                     .filter(path -> !getFileName(path).startsWith("notice"))
                     // dual-licensed under GPL 2 and CDDL 1.1
                     // contained in hadoop/presto S3 FS and paimon-dist
-                    .filter(path -> !pathStartsWith(path, "/META-INF/versions/11/javax/xml/bind"))
+                    .filter(path -> !path.toString().contains("/META-INF/versions/11/javax/xml/bind"))
                     .filter(path -> !isJavaxManifest(jar, path))
                     // dual-licensed under GPL 2 and EPL 2.0
                     // contained in sql-avro-confluent-registry


### PR DESCRIPTION
In https://github.com/apache/incubator-paimon/pull/1996 , plugins will be placed in subdirectories (instead of nested jars) in the distrubution jar. This PR adapts `JarFileChecker` to fit this new layout.